### PR TITLE
always tag with NPR

### DIFF
--- a/classes/NPRAPIWordpress.php
+++ b/classes/NPRAPIWordpress.php
@@ -153,6 +153,8 @@ class NPRAPIWordpress extends NPRAPI {
 
                 if( false !== $qnum ) {
                     $args['tags_input'] = 'NPR, ' . get_option('ds_npr_query_tags_'.$qnum);
+                } else {
+                    $args['tags_input'] = 'NPR';
                 }
 				//check the last modified date and pub date (sometimes the API just updates the pub date), if the story hasn't changed, just go on
                 if ( $post_mod_date != strtotime( $story->lastModifiedDate->value ) || $post_pub_date !=  strtotime( $story->pubDate->value ) ) {


### PR DESCRIPTION
fixing a bug with previous commit to ensure that imported posts are
always tagged with NPR
